### PR TITLE
Fix Ktor Serialization Issue on iOS

### DIFF
--- a/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/src/main/kotlin/Deps.kt
@@ -67,7 +67,7 @@ object Deps {
         }
 
         object Coroutines {
-            const val version = "1.4.3-native-mt"
+            const val version = "1.5.0-native-mt"
             const val common = "org.jetbrains.kotlinx:kotlinx-coroutines-core:$version"
             const val android = "org.jetbrains.kotlinx:kotlinx-coroutines-android:$version"
         }

--- a/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
+++ b/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6356313620DC58F600BCCDF9"
+            BuildableName = "iosApp.app"
+            BlueprintName = "iosApp"
+            ReferencedContainer = "container:iosApp.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "6356313620DC58F600BCCDF9"
-            BuildableName = "iosApp.app"
-            BlueprintName = "iosApp"
-            ReferencedContainer = "container:iosApp.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -77,8 +75,6 @@
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/sessionize/lib/build.gradle.kts
+++ b/sessionize/lib/build.gradle.kts
@@ -81,7 +81,11 @@ kotlin {
                 implementation(Deps.multiplatformSettings)
                 implementation(Deps.Serialization.commonRuntime)
                 implementation(Deps.Firebase.GitLive.firestore)
-                implementation(Deps.Kotlin.Coroutines.common)
+                implementation(Deps.Kotlin.Coroutines.common) {
+                    version {
+                        strictly(Deps.Kotlin.Coroutines.version)
+                    }
+                }
 
                 implementation(Deps.Ktor.commonCore)
                 implementation(Deps.Ktor.commonJson)


### PR DESCRIPTION
This fixes Serialization issue occurring on iOS. Ktor Serialization seems to freeze during serialization causing `InvalidMutabilityException` on iOS. 

As a workaround as mentioned on [here](https://github.com/Kotlin/kotlinx.serialization/issues/1450#issuecomment-841214332), disabling `useAlternativeNames` would resolve the said issue. Once the issue gets resolve, this must be revisited as well.